### PR TITLE
fix(tracing): rename WasiProcessor to WasiSpanProcessor

### DIFF
--- a/rust/examples/spin-basic/src/lib.rs
+++ b/rust/examples/spin-basic/src/lib.rs
@@ -14,7 +14,7 @@ use opentelemetry::{
 #[http_component]
 fn handle_spin_basic(_req: Request) -> anyhow::Result<impl IntoResponse> {
     // Set up a tracer using the WASI processor
-    let wasi_processor = opentelemetry_wasi::WasiProcessor::new();
+    let wasi_processor = opentelemetry_wasi::WasiSpanProcessor::new();
     let tracer_provider = SdkTracerProvider::builder()
         .with_span_processor(wasi_processor)
         .build();

--- a/rust/examples/spin-tracing/src/lib.rs
+++ b/rust/examples/spin-tracing/src/lib.rs
@@ -15,7 +15,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 #[http_component]
 fn handle_spin_tracing(_req: Request) -> anyhow::Result<impl IntoResponse> {
     // Set up a tracer using the WASI processor
-    let wasi_processor = opentelemetry_wasi::WasiProcessor::new();
+    let wasi_processor = opentelemetry_wasi::WasiSpanProcessor::new();
     let provider = SdkTracerProvider::builder()
         .with_span_processor(wasi_processor)
         .build();

--- a/rust/src/tracing.rs
+++ b/rust/src/tracing.rs
@@ -2,6 +2,6 @@ mod conversion;
 mod processor;
 mod propagation;
 
-pub use processor::WasiProcessor;
+pub use processor::WasiSpanProcessor;
 pub use propagation::TraceContextPropagator;
 pub use propagation::WasiPropagator;

--- a/rust/src/tracing/processor.rs
+++ b/rust/src/tracing/processor.rs
@@ -3,12 +3,12 @@ use opentelemetry_sdk::{error::OTelSdkResult, trace::SpanProcessor};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 #[derive(Debug)]
-pub struct WasiProcessor {
+pub struct WasiSpanProcessor {
     is_shutdown: AtomicBool,
 }
 
-impl WasiProcessor {
-    /// Create a new `WasiProcessor`.
+impl WasiSpanProcessor {
+    /// Create a new `WasiSpanProcessor`.
     pub fn new() -> Self {
         Self {
             is_shutdown: AtomicBool::new(false),
@@ -16,13 +16,13 @@ impl WasiProcessor {
     }
 }
 
-impl Default for WasiProcessor {
+impl Default for WasiSpanProcessor {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl SpanProcessor for WasiProcessor {
+impl SpanProcessor for WasiSpanProcessor {
     fn on_start(&self, span: &mut opentelemetry_sdk::trace::Span, _: &opentelemetry::Context) {
         if self.is_shutdown.load(Ordering::Relaxed) {
             return;


### PR DESCRIPTION
This PR renames the `WasiProcessor` to `WasiSpanProcessor`. Closes #19. 