### PR TITLE
feat(test): adding trace parentage test

### DIFF
--- a/integration_tests/src/snapshots/integration_tests__tests__rust_spin_tracing_tracing.snap
+++ b/integration_tests/src/snapshots/integration_tests__tests__rust_spin_tracing_tracing.snap
@@ -1,6 +1,6 @@
 ---
 source: src/lib.rs
-expression: span_data
+expression: spans
 ---
 - trace_id: "[trace_id:len(32)]"
   span_id: "[span_id:len(16)]"


### PR DESCRIPTION
This adds a test that validates the parent-child ordering of an application's exported spans.

Closes #14 