### PR TITLE
fix: removing hardcoded traceflag

### DIFF
--- a/go/metrics/conversions.go
+++ b/go/metrics/conversions.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"encoding/hex"
 	"time"
 
 	"github.com/calebschoepp/opentelemetry-wasi/internal/wasi_clocks_wall_clock"
@@ -245,8 +246,8 @@ func toWasiExemplar[T float64 | int64](exemplars []metricdata.Exemplar[T]) []was
 			FilteredAttributes: types.ToWasiAttributes(e.FilteredAttributes),
 			Time:               types.ToWasiTime(e.Time),
 			Value:              toWasiMetricNumber(e.Value),
-			SpanId:             string(e.SpanID),
-			TraceId:            string(e.TraceID),
+			SpanId:             hex.EncodeToString(e.SpanID),
+			TraceId:            hex.EncodeToString(e.TraceID),
 		}
 	}
 

--- a/go/tracing/conversions.go
+++ b/go/tracing/conversions.go
@@ -119,10 +119,18 @@ func toOtelSpanContext(ctx wasi_otel_tracing.SpanContext) traceApi.SpanContext {
 		traceState = ts
 	}
 
+	var traceFlags traceApi.TraceFlags
+	switch ctx.TraceFlags {
+	case wasi_otel_tracing.TraceFlagsSampled:
+		traceFlags = traceApi.FlagsSampled
+	default:
+		// traceFlags is empty, which means FlagsNotSampled
+	}
+
 	return traceApi.NewSpanContext(traceApi.SpanContextConfig{
 		TraceID:    [16]byte(tid),
 		SpanID:     [8]byte(sid),
-		TraceFlags: traceApi.FlagsSampled,
+		TraceFlags: traceFlags,
 		TraceState: traceState,
 		Remote:     ctx.IsRemote,
 	})
@@ -138,10 +146,18 @@ func toWasiSpanContext(s traceApi.SpanContext) wasi_otel_tracing.SpanContext {
 		return true
 	})
 
+	var traceFlags wasi_otel_tracing.TraceFlags
+	switch s.TraceFlags() {
+	case traceApi.FlagsSampled:
+		traceFlags = wasi_otel_tracing.TraceFlagsSampled
+	default:
+		// traceFlags is empty, which means FlagsNotSampled
+	}
+
 	return wasi_otel_tracing.SpanContext{
 		TraceId:    s.TraceID().String(),
 		SpanId:     s.SpanID().String(),
-		TraceFlags: wasi_otel_tracing.TraceFlagsSampled,
+		TraceFlags: traceFlags,
 		IsRemote:   s.IsRemote(),
 		TraceState: traceState,
 	}


### PR DESCRIPTION
We had configured our host to sample traces, and we were getting random component traces that were detached from the larger host trace. This fix ensures that the exported component traces matches the context that the host provides.

Also, the exemplars conversion logic was flat out wrong. The tracing portion uses hex strings, and this was just raw converting bytes to string.